### PR TITLE
Enhancement/prune

### DIFF
--- a/stickord/commands/admin_tools.py
+++ b/stickord/commands/admin_tools.py
@@ -13,7 +13,7 @@ async def prune_messages(cont, mesg, client, *_args, **_kwargs):
     '''
     Deletes x messages from the channel this command is posted in (Moderator only).
     x does not include the command itself.
-    Can only delete messages from the last 14 days, up to 100 (including invocation). 
+    Can only delete messages from the last 14 days, up to 100 (including invocation).
     '''
     if cont:
         try:
@@ -38,7 +38,7 @@ async def prune_messages(cont, mesg, client, *_args, **_kwargs):
                     await client.delete_message(message)
             else:
                 await client.delete_messages(messages)
-            LOGGER.info(f'Deleted {amount} messaged from #{mesg.channel} by order of {mesg.author}')
+            LOGGER.info(f'Deleted {amount} messages from #{mesg.channel} by order of {mesg.author}')
             return None
         except ValueError:
             pass
@@ -64,7 +64,7 @@ async def force_prune_message(cont, mesg, client, *_args, **_kwargs):
             for message in messages:
                 await client.delete_message(message)
 
-            LOGGER.info(f'Force-deleted {amount} messaged from #{mesg.channel} by order of {mesg.author}')
+            LOGGER.info(f'Force-deleted {amount} messages from #{mesg.channel} by order of {mesg.author}')
             return None
 
         except ValueError:
@@ -77,7 +77,7 @@ async def force_prune_message(cont, mesg, client, *_args, **_kwargs):
 @role_whitelist(['Admin', 'Moderator'])
 async def exclusive_prune_messages(cont, mesg, client, *_args, **_kwargs):
     '''
-    Deletes up to x messages from the channel this command is posted in
+    Deletes up to x messages from the channel this command is posted in,
     skips messages that begin with string specified (Moderator only).
     x does not include the command itself.
     Can only delete messages from the last 14 days, up to 100 (including invocation).
@@ -111,7 +111,7 @@ async def exclusive_prune_messages(cont, mesg, client, *_args, **_kwargs):
                     await client.delete_message(message)
             else:
                 await client.delete_messages(messages)
-            LOGGER.info(f'Deleted {delcount} messaged from #{mesg.channel} by order of {mesg.author}')
+            LOGGER.info(f'Deleted {delcount} messages from #{mesg.channel} by order of {mesg.author}')
             return None
         except ValueError:
             pass
@@ -156,7 +156,7 @@ async def inclusive_prune_messages(cont, mesg, client, *_args, **_kwargs):
                     await client.delete_message(message)
             else:
                 await client.delete_messages(messages)
-            LOGGER.info(f'Deleted {delcount} messaged from #{mesg.channel} by order of {mesg.author}')
+            LOGGER.info(f'Deleted {delcount} messages from #{mesg.channel} by order of {mesg.author}')
             return None
         except ValueError:
             pass

--- a/stickord/commands/admin_tools.py
+++ b/stickord/commands/admin_tools.py
@@ -1,6 +1,7 @@
 '''
 Contains some Moderator and Admin only commands that are useful when moderating.
 '''
+from datetime import datetime, timedelta
 from stickord.registry import Command, get_easy_logger, role_whitelist
 
 LOGGER = get_easy_logger('commands.admin_tools')
@@ -18,13 +19,55 @@ async def prune_messages(cont, mesg, client, *_args, **_kwargs):
         try:
             messages = []
             amount = int(cont[0]) + 1
+
             if amount > 100:
                 return 'Can only delete a maximum of 99 messages at a time.'
-            async for m in client.logs_form(mesg.channel, limit=amount):
+            async for m in client.logs_from(mesg.channel, limit=amount):
+                if datetime.now() - m.timestamp > timedelta(days=14):
+                    LOGGER.warning(
+                        'Could not delete some messages, '
+                        'message might be older than 14 days. Timestamp: %s',
+                        m.timestamp
+                    )
+                    break
                 messages.append(m)
-            await client.delete_messages(messages)
-            LOGGER.log(f'Deleted {amount} messaged from {mesg.channel} by order of {mesg.author}')
+
+            # As bulk deletion only works with more than 2 messages catch exception
+            if amount <= 2:
+                for message in messages:
+                    await client.delete_message(message)
+            else:
+                await client.delete_messages(messages)
+            LOGGER.info(f'Deleted {amount} messaged from #{mesg.channel} by order of {mesg.author}')
             return None
         except ValueError:
             pass
+    return 'You have to enter the number of messages to be deleted.'
+
+
+@Command('forceprune', category='Tools', hidden=True)
+@role_whitelist(['Admin', 'Moderator'])
+async def force_prune_message(cont, mesg, client, *_args, **_kwargs):
+    '''
+    Prunes a channel whithout using bulkdelete (Moderator only).
+    May be used to delete messages over 14 days old.
+    Might be significantly slower than the regular prune command.
+    '''
+    if cont:
+        try:
+            messages = []
+            amount = int(cont[0]) + 1
+
+            async for m in client.logs_from(mesg.channel, limit=amount):
+                messages.append(m)
+
+            for message in messages:
+                await client.delete_message(message)
+
+            LOGGER.info(f'Force-deleted {amount} messaged from #{mesg.channel} by order of {mesg.author}')
+            return None
+
+        except ValueError:
+            pass
+
     return 'You have to enter the number of messages to be deleted.'

--- a/stickord/commands/admin_tools.py
+++ b/stickord/commands/admin_tools.py
@@ -1,0 +1,30 @@
+'''
+Contains some Moderator and Admin only commands that are useful when moderating.
+'''
+from stickord.registry import Command, get_easy_logger, role_whitelist
+
+LOGGER = get_easy_logger('commands.admin_tools')
+
+
+@Command('prune', category='Tools', hidden=True)
+@role_whitelist(['Admin', 'Moderator'])
+async def prune_messages(cont, mesg, client, *_args, **_kwargs):
+    '''
+    Deletes x messages from the channel this command is posted in (Moderator only).
+    x does not include the command itself.
+    Can only delete messages from the last 14 days, up to 100 (including invocation). 
+    '''
+    if cont:
+        try:
+            messages = []
+            amount = int(cont[0]) + 1
+            if amount > 100:
+                return 'Can only delete a maximum of 99 messages at a time.'
+            async for m in client.logs_form(mesg.channel, limit=amount):
+                messages.append(m)
+            await client.delete_messages(messages)
+            LOGGER.log(f'Deleted {amount} messaged from {mesg.channel} by order of {mesg.author}')
+            return None
+        except ValueError:
+            pass
+    return 'You have to enter the number of messages to be deleted.'


### PR DESCRIPTION
- `!prune x` will delete the last x messages in bulk from the channel it
is posted in, the command itself does not count.
- `!prune` can only handle deletions up to 99 messages and to a maximum
of 14 days old.
- `!forceprune x` forces the last x messages to be deleted one by one,
this allows for deletions of messages over 14 days old. This command
should not be used for large deletions.